### PR TITLE
Add Node.js v24.13.1 support to engines and bump plugin to v0.5.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v0.5.48
+- Add support for Node.js v24.13.1 in the Homebridge plugin engine requirements
+
 ### v0.5.46
 - Update thermostat structure to new format
 - Update thermostat to have min/max thresholds closer to Wyze Thermostat thresholds -  https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/203

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 For more information about our version updates, please check our [change log](CHANGELOG.md).
 
+## Requirements
+- Node.js 18.20.4, 20.15.1, or 24.13.1
+- Homebridge 1.6.0+ (or 2.0.0 beta)
+
 ## Configuration
 
 Use the settings UI in Homebridge Config UI X to configure your Wyze account, or manually add the following to the platforms section of your config file:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.47",
+  "version": "0.5.48",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
@@ -22,9 +22,10 @@
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0-beta.0",
-    "node": "^18.20.4 || ^20.15.1"
+    "node": "^18.20.4 || ^20.15.1 || ^24.13.1"
   },
   "dependencies": {
+    "aws-sdk": "2.1693.0",
     "axios": "^1.5.0",
     "base64-js": "1.5.1",
     "colorsys": "^1.0.22",
@@ -38,8 +39,7 @@
     "utf8": "^3.0.0",
     "uuid": "8.3.2",
     "uuid-by-string": "4.0.0",
-    "wyze-api": "1.1.7",
-    "aws-sdk": "2.1693.0"
+    "wyze-api": "1.1.7"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.27.1",


### PR DESCRIPTION
### Motivation
- Ensure the plugin explicitly advertises compatibility with Node.js `v24.13.1` and publish a small version bump to record the compatibility change.

### Description
- Updated `package.json` to include `"node": "^18.20.4 || ^20.15.1 || ^24.13.1"` and bumped the package `version` to `0.5.48`, added a `v0.5.48` entry to `CHANGELOG.md`, and added a `## Requirements` section to `README.md` listing supported Node.js and Homebridge versions.

### Testing
- Ran `node -e "const p=require('./package.json'); console.log(p.version, p.engines.node)"` which printed the new version and engine range (succeeded).
- Ran `npm pack --dry-run` to validate the package contents (succeeded).
- Ran `npm run lint` which failed because the repo has no ESLint configuration file (expected failure in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996abaac8688325b78b6c826ec0a9e3)