### PR TITLE
Update package.json to scoped npm name and GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-wyze-smart-home",
+  "name": "@homebridge-wyze-node24/homebridge-wyze-node24",
   "version": "0.5.48",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
@@ -12,13 +12,13 @@
     "Wyze",
     "Hoobs"
   ],
-  "homepage": "http://github.com/jfarmer08/homebridge-wyze-smart-home",
+  "homepage": "https://github.com/rtrappman-dev/homebridge-wyze-node24/tree/main",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jfarmer08/homebridge-wyze-smart-home.git"
+    "url": "https://github.com/rtrappman-dev/homebridge-wyze-node24/tree/main"
   },
   "bugs": {
-    "url": "http://github.com/jfarmer08/homebridge-wyze-smart-home/issues"
+    "url": "https://github.com/rtrappman-dev/homebridge-wyze-node24/tree/main/issues"
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0-beta.0",


### PR DESCRIPTION
### Motivation
- Rename the package to the new scoped npm name and update GitHub metadata so package registry and project pages point to the new `rtrappman-dev/homebridge-wyze-node24` repository.

### Description
- Updated `package.json` to set `"name": "@homebridge-wyze-node24/homebridge-wyze-node24"` and replaced `homepage`, `repository.url`, and `bugs.url` with `https://github.com/rtrappman-dev/homebridge-wyze-node24/tree/main`-based URLs.

### Testing
- Validated `package.json` is syntactically correct by running `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json valid JSON')"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996b696cbb88325a39a5a25a6d9fc3e)