### PR TITLE
ci: upgrade CodeQL workflow actions to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Motivation
- Upgrade CodeQL-related actions to v4 so the workflow remains compatible with the upcoming deprecation of CodeQL Action v3.

### Description
- Bumped `actions/checkout@v3` to `@v4` and `github/codeql-action/{init,autobuild,analyze}@v3` to `@v4` in `.github/workflows/codeql.yml`.

### Testing
- Verified the change by running `git diff -- .github/workflows/codeql.yml` and inspecting the updated file with `nl -ba .github/workflows/codeql.yml | sed -n '34,80p'`, both of which show the action versions updated to `@v4`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996bb3cbc008325ab7bb12691827182)