### PR TITLE
fix: remove unused homebridge-config-ui-x dependency for Node 24 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "base64-js": "1.5.1",
     "colorsys": "^1.0.22",
     "crypto-js": "4.2.0",
-    "homebridge-config-ui-x": "^4.56.4",
     "inherits": "2.0.4",
     "md5": "^2.2.1",
     "moment": "2.29.4",


### PR DESCRIPTION
### Motivation
- Remove `homebridge-config-ui-x` because it pulls in a native build chain (`@homebridge/node-pty-prebuilt-multiarch` / `nan`) that fails to compile under Node.js v24 while the plugin source does not use it.

### Description
- Delete the `homebridge-config-ui-x` entry from `dependencies` in `package.json` so runtime installs no longer pull in the problematic native `node-pty` package.

### Testing
- Confirmed no source references with `rg "homebridge-config-ui-x|node-pty|pty" -n src package.json` and verified the dependency was removed with `npm pkg get dependencies.homebridge-config-ui-x`, attempted `npm install --omit=dev` (failed due to a registry `403` unrelated to this change), and ran `yarn install` which completed with warnings; these automated checks validate the manifest change in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6996c272e47c8325a874e348b4d6c564)